### PR TITLE
Allow overriding the default `MockPayloadGenerator.generate` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ export const Default = {
 - `getReferenceEntry`: A function that returns an entry to be added to the story's args. It takes the result of the `useLazyLoadQuery` hook with the query passed as a parameter and returns an entry to be added to the story's args.
 - `variables`: Optional. Variables to pass to the query.
 - `mockResolvers`: Optional. A mock resolver object passed to the `relay-test-utils`' `MockPayloadGenerator.generate` function.
+- `generateFunction`: Optional. A function which allows you to override the default MockPayloadGenerator.generate function.
 
 Here is a minimal example:
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@imchhh/storybook-addon-relay",
   "type": "commonjs",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "A Storybook add-on to write stories for Relay components.",
   "main": "dist/preset.js",
   "types": "dist/index.d.ts",

--- a/src/decorators/withRelay.tsx
+++ b/src/decorators/withRelay.tsx
@@ -34,6 +34,7 @@ export type WithRelayParameters<
         operation: OperationDescriptor,
         mockResolvers?: MockResolvers | null,
     ) => GraphQLSingularResponse;
+
     /**
      * A function that returns an entry to be added to the story's args.
      *

--- a/src/decorators/withRelay.tsx
+++ b/src/decorators/withRelay.tsx
@@ -1,7 +1,9 @@
 import { makeDecorator } from '@storybook/addons';
 import { RelayEnvironmentProvider, useLazyLoadQuery } from 'react-relay';
-import { GraphQLTaggedNode, OperationType } from 'relay-runtime';
+import { GraphQLSingularResponse, GraphQLTaggedNode, OperationDescriptor, OperationType } from 'relay-runtime';
 import { createMockEnvironment, MockPayloadGenerator } from 'relay-test-utils';
+import { MockResolvers } from 'relay-test-utils/lib/RelayMockPayloadGenerator';
+import { OperationMockResolver } from 'relay-test-utils/lib/RelayModernMockEnvironment';
 import { InferMockResolvers } from './types';
 
 export type WithRelayParameters<
@@ -24,6 +26,14 @@ export type WithRelayParameters<
      * If you use TResolver type argument, you can get type safety <3
      */
     mockResolvers?: InferMockResolvers<TResolvers>;
+
+    /**
+     * Optional. A function which allows you to override the default MockPayloadGenerator.generate function.
+     */
+    generateFunction?: (
+        operation: OperationDescriptor,
+        mockResolvers?: MockResolvers | null,
+    ) => GraphQLSingularResponse;
     /**
      * A function that returns an entry to be added to the story's args.
      *
@@ -72,6 +82,9 @@ export const withRelay = makeDecorator({
     const environment = createMockEnvironment();
 
     environment.mock.queueOperationResolver((operation) => {
+      if (pars.generateFunction) {
+        return pars.generateFunction(operation, mockResolvers);
+      }
       return MockPayloadGenerator.generate(operation, mockResolvers);
     });
 


### PR DESCRIPTION
Hi,

this addon works great in my project, however there is one feature I was missing. I want to use a newer Relay feature `MockPayloadGenerator.generateWithDefer`. This is to generate deferred data for queries using `@defer`. To allow this, I decided to use a more generic approach, adding a parameter which allows the user to override which function to use for the generation. I decided to do it like that because it is more flexible, but also because for my use-case, the types for `MockPayloadGenerator.generateWithDefer` is not exposed in `@types/relay-test-utils` yet.

I was not able to run the storybooks, so I have not tested those, but I tested it in my project, and it works great.

Let me know if there is something missing or other concerns with merging this (note that I bumped the version in package.json) :)