### PR TITLE
Fix invalid path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "type": "commonjs",
   "version": "0.0.11",
   "description": "A Storybook add-on to write stories for Relay components.",
-  "main": "dist/preset.js",
+  "main": "preset.js",
   "types": "dist/index.d.ts",
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
In package.json, we have `main: "dist/preset.js"`, but the `preset.js` file is in the root, not the `dist` folder, this PR fixes that.