### PR TITLE
Make @storybook/addons a peer-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@imchhh/storybook-addon-relay",
   "type": "commonjs",
-  "version": "0.0.11",
+  "version": "0.0.13",
   "description": "A Storybook add-on to write stories for Relay components.",
   "main": "preset.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "vite-plugin-dts": "^2.0.2"
   },
   "peerDependencies": {
+    "@storybook/addons": "^6 || ^7",
     "react": "^17 || ^18",
     "react-dom": "^17 || ^18",
     "react-relay": "^14 || ^15 || ^16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1782,11 +1782,12 @@ __metadata:
     vite: ^4.1.4
     vite-plugin-dts: ^2.0.2
   peerDependencies:
+    "@storybook/addons": ^6 || ^7
     react: ^17 || ^18
     react-dom: ^17 || ^18
-    react-relay: ^14
-    relay-runtime: ^14
-    relay-test-utils: ^14
+    react-relay: ^14 || ^15 || ^16
+    relay-runtime: ^14 || ^15 || ^16
+    relay-test-utils: ^14 || ^15 || ^16
   peerDependenciesMeta:
     relay-runtime:
       optional: true


### PR DESCRIPTION
Hi,

`@storybook/addons` should be a peer-dependency since it is used in `withRelay.tsx`. This PR fixes that.

I also bumped the version to 0.0.13. 😄 